### PR TITLE
Added order of test execution

### DIFF
--- a/src/pages/docs/writing-scripts/test-scripts.md
+++ b/src/pages/docs/writing-scripts/test-scripts.md
@@ -148,7 +148,7 @@ There's a selection of commonly-used test code excerpts in __Snippets__ to the r
 
 ## Testing collections and folders
 
-You can add test scripts to a collection, a folder, or a single request within a collection. A test script associated with a collection will run after every request in the collection. A test script associated with a folder will run after every request in the folder. This enables you to reuse commonly executed tests after every request.
+You can add test scripts to a collection, a folder, or a single request within a collection. A test script associated with a collection will run after every request in the collection. A test script associated with a folder will run after every request in the folder. This enables you to reuse commonly executed tests after every request. The execution order for each request will be collection tests, folder tests and then request tests.
 
 Adding scripts to collections and folders enables you to test the workflows in your API project. This helps to ensure that your requests cover typical scenarios, providing a reliable experience for application users.
 


### PR DESCRIPTION
Add execution order of tests as it's it not intuitive at all. The common perception is they will run last and not first. This is not documented anywhere.